### PR TITLE
Provide an all-in-one app deploy YAML file

### DIFF
--- a/deploy/all-in-one/devops-sample.yaml
+++ b/deploy/all-in-one/devops-sample.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kubesphere
+    component: ks-sample-dev
+    tier: backend
+  name: ks-sample-dev
+  namespace: $PROJECT_NAME
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubesphere
+      component: ks-sample-dev
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: kubesphere
+        component: ks-sample-dev
+        tier: backend
+    spec:
+      containers:
+        - env:
+            - name: CACHE_IGNORE
+              value: js|html
+            - name: CACHE_PUBLIC_EXPIRATION
+              value: 3d
+          image: $REGISTRY/$HARBOR_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            timeoutSeconds: 10
+            failureThreshold: 30
+            periodSeconds: 5
+          imagePullPolicy: Always
+          name: ks-sample
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 300m
+              memory: 600Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kubesphere
+    component: ks-sample-dev
+  name: ks-sample-dev
+  namespace: $PROJECT_NAME
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+      nodePort: 30861
+  selector:
+    app: kubesphere
+    component: ks-sample-dev
+    tier: backend
+  sessionAffinity: None
+  type: NodePort


### PR DESCRIPTION
An all-in-one file is useful for the following use case:

```shell
sh 'envsubst < devops-go-sample/deploy/all-in-one/devops-sample.yaml | kubectl apply -f -'
```