### PR TITLE
Remove Unused MAVEN_ARGS_APPEND config item

### DIFF
--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,3 +1,2 @@
 S2I_DESTINATION=/tmp
-MAVEN_ARGS_APPEND=-Dmaven.repo.local=/tmp/src/artifacts/m2 -o
 DISABLE_ARTIFACTS=true


### PR DESCRIPTION
### What this PR dose

Remove Unused MAVEN_ARGS_APPEND config item.

### Why we need it

Because this project is migrated from https://github.com/kubesphere/devops-java-sample, but without offline support. So the Maven args won't work in this project.

![image](https://user-images.githubusercontent.com/16865714/146495336-558bcf6e-91db-4ec1-bd6b-7eeb9b776a89.png)

### How to test it

0. Create a project and create a `docker-id` secret in it
1. Go to `Image Builders` page and click `Create` button
2. Select `Java` in `Build Image from Source Code`
3. Set `Code Repository URL` and `Code Repository Branch` to `https://github.com/JohnNiang/devops-maven-sample` and `bug/s2i-build` respectively
4. Input `Image Name` and select `Target Image Registry*`
5. Click `Create` button and see the result

![image](https://user-images.githubusercontent.com/16865714/146495309-9a7bd47e-ee08-4b11-8617-b47cbbc7c179.png)

/kind bug
/cc @kubesphere/sig-devops 